### PR TITLE
chore(deps): bump all actions up to date

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Validate
-        uses: rinchsan/renovate-config-validator@v0.0.11
+        uses: rinchsan/renovate-config-validator@v0.2.0
         with:
           pattern: 'default.json'


### PR DESCRIPTION
This commit includes the following changes:
- chore(deps): update `actions/checkout` to v4
- chore(deps): update `rinchsan/renovate-config-validator` to v0.2.0